### PR TITLE
Added sorting for M-phi vectors along phi

### DIFF
--- a/RCBeam/RCBeam/MomentAnalysis.cpp
+++ b/RCBeam/RCBeam/MomentAnalysis.cpp
@@ -256,4 +256,3 @@ double epsilon_steel(double c_na, double depth, double eps_cm)
 {
 	return (eps_cm * (c_na - depth) / c_na);
 }
-

--- a/RCBeam/RCBeam/MomentAnalysis.h
+++ b/RCBeam/RCBeam/MomentAnalysis.h
@@ -22,3 +22,31 @@ double EquilibriumForces(double c_na,
 double Beta1(std::shared_ptr<Concrete>& pConcrete);
 
 double epsilon_steel(double c_na, double depth, double eps_cm);
+
+// Fill the zipped vector with pairs consisting of the
+// corresponding elements of a and b. (This assumes 
+// that the vectors have equal length)
+template <typename A, typename B>
+void zip(const std::vector<A>& a, const std::vector<B>& b, std::vector<std::pair<A, B>>& zipped)
+{
+	for (size_t i = 0; i < a.size(); ++i)
+	{
+		zipped.push_back(std::make_pair(a[i], b[i]));
+	}
+}
+
+// Write the first and second element of the pairs in 
+// the given zipped vector into a and b. (This assumes 
+// that the vectors have equal length)
+template <typename A, typename B>
+void unzip(
+	const std::vector<std::pair<A, B>>& zipped,
+	std::vector<A>& a,
+	std::vector<B>& b)
+{
+	for (size_t i = 0; i < a.size(); i++)
+	{
+		a[i] = zipped[i].first;
+		b[i] = zipped[i].second;
+	}
+}

--- a/RCBeam/RCBeam/main.cpp
+++ b/RCBeam/RCBeam/main.cpp
@@ -119,8 +119,20 @@ int main()
     }
 
 
-    // TODO: Sort M,phi before running p-delta analysis.
-    std::sort(phi.begin(), phi.end());
+    //// TODO: Sort M,phi before running p-delta analysis.
+    //// Zip vectors together
+    //std::vector<std::pair<double,double>> zipped;
+    //zip(phi, M, zipped);
+
+    //// Sort the vector of pairs
+    //std::sort(std::begin(zipped), std::end(zipped),
+    //    [&](const auto& a, const auto& b)
+    //    {
+    //        return a.first > b.first;
+    //    });
+
+    //// Write the sorted pairs back to the original vectors
+    //unzip(zipped, phi, M);
 
     // Load-displacement calculations -- need full moment-curvature relationship
     // create vector of loads:

--- a/RCBeam/RCBeam/pch.h
+++ b/RCBeam/RCBeam/pch.h
@@ -10,3 +10,5 @@
 #include "MathLibrary.h"
 #include <memory>
 #include <algorithm>
+#include <string>
+#include <iterator>


### PR DESCRIPTION
Added sorting for M-phi. There is still an issue with the moment not being monotonically increasing. Might have to change load-deflection algorithm to cut-off at max moment; this would account for plastic yield. Logically can't increase moment past that without violating the starting static assumptions; Move to virtual work instead? Have to think about this.